### PR TITLE
Add RainLab\Translate support

### DIFF
--- a/models/Category.php
+++ b/models/Category.php
@@ -19,6 +19,12 @@ class Category extends Model
         'title' => 'required',
         'lang' => 'string',
     ];
+    
+    /**
+     * @var array Translatable fields
+     */
+    public $translatable = ['title'];
+    
     /**
      * @var array Guarded fields
      */
@@ -36,5 +42,28 @@ class Category extends Model
         'question' => 'RedMarlin\Faq\Models\Question'
     ];
     public $timestamps = false; 
+    
+    /**
+     * Add translation support to this model, if available.
+     * @return void
+     */
+    public static function boot()
+    {
+        // Call default functionality (required)
+        parent::boot();
+
+        // Check the translate plugin is installed
+        if (!class_exists('RainLab\Translate\Behaviors\TranslatableModel')) {
+            return;
+        }
+
+        // Extend the constructor of the model
+        self::extend(function ($model) {
+
+            // Implement the translatable behavior
+            $model->implement[] = 'RainLab.Translate.Behaviors.TranslatableModel';
+
+        });
+    }
 
 }


### PR DESCRIPTION
Added boot method for RainLab\Translate support. 
Added $translatable array to mark translatable fields. 

I guess you should remove the `lang` column from the table.